### PR TITLE
Add Mongrel to Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@
 - [DBeaver](https://github.com/dbeaver/dbeaver) - Free universal database tool and SQL client. 👏
 - [Gun](https://github.com/amark/gun) - Gun is an open-source and realtime, decentralized, offline-first, graph database engine written in JavaScript. 👏
 - [Mongodb Compass](https://www.mongodb.com/products/compass) - Nice GUI for MongoDB with dark mode included.
+- [Mongrel](https://www.visorcraft.com/) - Desktop workbench for 30+ database engines, with terminals, SFTP, Docker, and Kubernetes.
 - [Postbird](https://github.com/Paxa/postbird) - Cross-platform PostgreSQL GUI client, written in JavaScript, runs with Electron. 👏
 - [Postgres admin](https://www.pgadmin.org/download/) - Free Postgres admin GUI, you can export and import database and rarely fail.
 - [Robo 3T](https://robomongo.org/) - Free lightweight GUI for MongoDB enthusiasts.


### PR DESCRIPTION
Adds [Mongrel](https://www.visorcraft.com/) to Databases, after MongoDB Compass.

Mongrel is a Linux desktop workbench for 30+ database engines (AppImage, .deb, and .rpm). It is proprietary, so it is listed without the open-source clap, same as MongoDB Compass.

Homepage only.